### PR TITLE
Update Symfony finder.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "behat/gherkin": "^4.6",
         "composer-plugin-api": "^1.1",
         "nategood/commando": "^0.4",
-        "symfony/finder": "^3",
+        "symfony/finder": "^4",
         "jawira/case-converter": "^3.4",
         "nette/php-generator": "^3.3"
     },


### PR DESCRIPTION
There is a problem with new site skel 7.x, where probably is required a higher version of symfony finder.

It's part of https://digitalpfizer.atlassian.net/browse/EDN-4869